### PR TITLE
Remove unnecessary https://www. prefix from link

### DIFF
--- a/pool.tex
+++ b/pool.tex
@@ -34,7 +34,7 @@
 	\item Try not to break things and ruin the fun for everyone
 	\item For enquiries or to report issues, please contact either
 	\begin{list}{\hspace{1.5em}\textbullet\hspace{0.5em}}{}
-		\item \texttt{https://www.facebook.com/groups/ComSSA/}
+		\item \texttt{facebook.com/groups/ComSSA/}
 		\item \texttt{comssa@lists.curtin.edu.au}
 	\end{list}
 \end{list}


### PR DESCRIPTION
I don't think this is really required. In addition, the combination of centering and left align for lines that only make it about 2/3 of the way across the page freaks me out, but I don't have the ability to fix it in TeX. I make my signs in PS ^_^
